### PR TITLE
feat(mcp-server): implement queryRASS tool endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,16 +58,20 @@ services:
     container_name: rass_engine_app
     ports:
       - "8000:8000"
-    # volumes: # Uncomment and adjust if you need persistent storage or live reload
-      # - ./rass-engine-service:/usr/src/app/rass-engine-service
     env_file:
       - ./rass-engine-service/.env
     depends_on:
       opensearch:
-        condition: service_healthy # Waits for OpenSearch to be healthy
+        condition: service_healthy
     networks:
       - rass_network
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
 
   mcp-server:
     build:

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -1,18 +1,56 @@
 // mcp-server/index.js
 const express = require('express');
+const axios = require('axios'); // Import axios
 const app = express();
 
 const PORT = process.env.MCP_SERVER_PORT || 8080;
 
 app.use(express.json());
 
-// A simple root route to check if the server is alive
 app.get('/', (req, res) => {
   res.status(200).send('MCP Server is running.');
 });
 
-// We will add the /invoke_tool endpoint here in the next issue
-// app.post('/invoke_tool', (req, res) => { ... });
+// The endpoint is now async to handle the axios call
+app.post('/invoke_tool', async (req, res) => {
+  const { tool_name, arguments: tool_args } = req.body;
+
+  console.log(`[MCP Server] Received tool call for: '${tool_name}'`);
+  console.log(`[MCP Server] Arguments:`, tool_args);
+
+  if (tool_name === 'queryRASS') {
+    try {
+      // The URL uses the Docker service name 'rass-engine-service'
+      const rassEngineUrl = 'http://rass-engine-service:8000/ask';
+      console.log(`[MCP Server] Forwarding query to RASS Engine at ${rassEngineUrl}`);
+
+      // Make the POST request to the RASS engine
+      const response = await axios.post(rassEngineUrl, {
+        query: tool_args.query,
+        top_k: tool_args.top_k, // Forward top_k if it exists
+      });
+
+      // Send the response from the RASS engine back to the original caller
+      res.status(200).json({
+        tool_name: 'queryRASS',
+        status: 'success',
+        result: response.data, // Pass through the result from the RASS engine
+      });
+    } catch (error) {
+      console.error('[MCP Server] Error calling RASS Engine:', error.message);
+      // Forward the error status and message if available
+      res.status(error.response?.status || 500).json({
+        tool_name: 'queryRASS',
+        status: 'error',
+        error: error.response?.data?.error || 'Failed to connect to RASS Engine.',
+      });
+    }
+  } else {
+    res.status(400).json({
+      error: `Tool '${tool_name}' is not supported by this server.`
+    });
+  }
+});
 
 app.listen(PORT, () => {
   console.log(`MCP Server listening on http://localhost:${PORT}`);

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "axios": "^1.9.0",
     "express": "^5.1.0"
   }
 }

--- a/rass-engine-service/Dockerfile
+++ b/rass-engine-service/Dockerfile
@@ -2,6 +2,9 @@
 # Consistent with the embedding-service
 FROM node:20-slim
 
+# Install curl for health checks and other utilities
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
 # Set the working directory in the container
 WORKDIR /usr/src/app/rass-engine-service
 

--- a/rass-engine-service/index.js
+++ b/rass-engine-service/index.js
@@ -36,6 +36,10 @@ const {
 
 app.use(express.json());
 
+app.get("/", (req, res) => {
+  res.status(200).json({ status: "ok", message: "RASS Engine is running" });
+});
+
 // EMBED_DIM is crucial and must match the target index AND the search term embedding model
 const EMBED_DIM =
   parseInt(process.env.EMBED_DIM, 10) ||
@@ -323,7 +327,7 @@ async function startServer() {
       }
     });
   } catch (e) {
-    console.error('Failed to start server:', e);
+    console.error("Failed to start server:", e);
     process.exit(1);
   }
 }


### PR DESCRIPTION
> Adds the /invoke_tool endpoint to the mcp-server.
> Implements the logic for the 'queryRASS' tool, including making a POST request to the rass-engine-service.
> Installs axios for inter-service communication.
> Updates the rass-engine-service with a Dockerfile healthcheck to ensure proper startup order in Docker Compose.
> Closes #14 