### PR TITLE
feat(mcp-server): implement addDocumentToRASS tool 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,8 @@ services:
     container_name: mcp_server_app
     ports:
       - "8080:8080"
+    volumes:
+      - ./embedding-service/uploads:/usr/src/app/uploads:ro
     networks:
       - rass_network
     depends_on:

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -1,53 +1,115 @@
 // mcp-server/index.js
-const express = require('express');
-const axios = require('axios'); // Import axios
+const express = require("express");
+const axios = require("axios");
+const FormData = require("form-data"); // Import FormData
+const fs = require("fs"); // Import Node.js File System module
+const path = require("path"); // Import path module
 const app = express();
 
 const PORT = process.env.MCP_SERVER_PORT || 8080;
 
 app.use(express.json());
 
-app.get('/', (req, res) => {
-  res.status(200).send('MCP Server is running.');
+app.get("/", (req, res) => {
+  res.status(200).send("MCP Server is running.");
 });
 
-// The endpoint is now async to handle the axios call
-app.post('/invoke_tool', async (req, res) => {
+app.post("/invoke_tool", async (req, res) => {
   const { tool_name, arguments: tool_args } = req.body;
 
   console.log(`[MCP Server] Received tool call for: '${tool_name}'`);
   console.log(`[MCP Server] Arguments:`, tool_args);
 
-  if (tool_name === 'queryRASS') {
+  if (tool_name === "queryRASS") {
     try {
-      // The URL uses the Docker service name 'rass-engine-service'
-      const rassEngineUrl = 'http://rass-engine-service:8000/ask';
-      console.log(`[MCP Server] Forwarding query to RASS Engine at ${rassEngineUrl}`);
+      const rassEngineUrl = "http://rass-engine-service:8000/ask";
+      console.log(
+        `[MCP Server] Forwarding query to RASS Engine at ${rassEngineUrl}`
+      );
 
-      // Make the POST request to the RASS engine
       const response = await axios.post(rassEngineUrl, {
         query: tool_args.query,
-        top_k: tool_args.top_k, // Forward top_k if it exists
+        top_k: tool_args.top_k,
       });
 
-      // Send the response from the RASS engine back to the original caller
       res.status(200).json({
-        tool_name: 'queryRASS',
-        status: 'success',
-        result: response.data, // Pass through the result from the RASS engine
+        tool_name: "queryRASS",
+        status: "success",
+        result: response.data,
       });
     } catch (error) {
-      console.error('[MCP Server] Error calling RASS Engine:', error.message);
-      // Forward the error status and message if available
+      console.error("[MCP Server] Error calling RASS Engine:", error.message);
       res.status(error.response?.status || 500).json({
-        tool_name: 'queryRASS',
-        status: 'error',
-        error: error.response?.data?.error || 'Failed to connect to RASS Engine.',
+        tool_name: "queryRASS",
+        status: "error",
+        error:
+          error.response?.data?.error || "Failed to connect to RASS Engine.",
+      });
+    }
+  } else if (tool_name === "addDocumentToRASS") {
+    const { source_uri } = tool_args;
+    if (!source_uri) {
+      return res
+        .status(400)
+        .json({ error: "Missing 'source_uri' in arguments." });
+    }
+
+    // This is the path *inside the mcp-server container* where the volume is mounted.
+    const fullPath = path.join("/usr/src/app/uploads", source_uri);
+
+    console.log(`[MCP Server] Attempting to read document from: ${fullPath}`);
+
+    if (!fs.existsSync(fullPath)) {
+      console.error(`[MCP Server] File not found at path: ${fullPath}`);
+      return res
+        .status(404)
+        .json({ error: `File not found at source_uri: ${source_uri}` });
+    }
+
+    try {
+      const form = new FormData();
+      // Use the original filename for the form-data part
+      form.append(
+        "files",
+        fs.createReadStream(fullPath),
+        path.basename(fullPath)
+      );
+
+      const embeddingServiceUrl = "http://embedding-service:8001/upload";
+      console.log(
+        `[MCP Server] Forwarding document to Embedding Service at ${embeddingServiceUrl}`
+      );
+
+      const response = await axios.post(embeddingServiceUrl, form, {
+        headers: {
+          ...form.getHeaders(),
+        },
+      });
+
+      console.log(
+        "[MCP Server] Successfully received response from Embedding Service."
+      );
+      return res.status(200).json({
+        tool_name: "addDocumentToRASS",
+        status: "success",
+        result: response.data,
+      });
+    } catch (error) {
+      console.error(
+        "[MCP Server] Error calling Embedding Service:",
+        error.response?.data || error.message
+      );
+      return res.status(error.response?.status || 500).json({
+        tool_name: "addDocumentToRASS",
+        status: "error",
+        error:
+          error.response?.data?.error ||
+          "Failed to connect to Embedding Service.",
       });
     }
   } else {
     res.status(400).json({
-      error: `Tool '${tool_name}' is not supported by this server.`
+      error: `Tool '${tool_name}' is not supported by this server.`,
     });
   }
 });

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -12,6 +12,7 @@
   "type": "commonjs",
   "dependencies": {
     "axios": "^1.9.0",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "form-data": "^4.0.3"
   }
 }


### PR DESCRIPTION
- Extends the /invoke_tool endpoint to handle the 'addDocumentToRASS' tool.
- The server now reads the file specified by 'source_uri' from a shared volume and forwards it as multipart/form-data to the embedding-service.
- Adds 'form-data' and 'axios' as dependencies to the mcp-server.
- Updates the docker-compose.yml to mount a shared uploads volume for the mcp-server.

- Closes #16