### PR TITLE
docs: finalize all README files after MCP validation

### DIFF
--- a/embedding-service/README.md
+++ b/embedding-service/README.md
@@ -8,11 +8,11 @@ This service is intended to be run as part of the Docker Compose environment def
 
 ## 🔧 Features
 
--   **Multi-Provider Embeddings:** Natively supports embedding models from both **OpenAI** (e.g., `text-embedding-3-small`) and **Google Gemini** (e.g., `text-embedding-004`).
--   **Dynamic Index Management:** Automatically creates and targets OpenSearch indexes based on the chosen embedding provider and model (e.g., `knowledge_base_openai_...` or `knowledge_base_gemini_...`), ensuring separation of data.
--   **Multiple File Format Support:** Extracts text from `.txt`, `.md`, `.json`, `.pdf`, and `.docx` files.
--   **Robust Ingestion:** Chunks large documents into appropriately sized pieces for embedding models.
--   **Containerized:** Designed to run as a service within the main project's Docker Compose setup.
+- **Multi-Provider Embeddings:** Natively supports embedding models from both **OpenAI** (e.g., `text-embedding-3-small`) and **Google Gemini** (e.g., `text-embedding-004`).
+- **Dynamic Index Management:** Automatically creates and targets OpenSearch indexes based on the chosen embedding provider and model (e.g., `knowledge_base_openai_...` or `knowledge_base_gemini_...`), ensuring separation of data.
+- **Multiple File Format Support:** Extracts text from `.txt`, `.md`, `.json`, `.pdf`, and `.docx` files.
+- **Robust Ingestion:** Chunks large documents into appropriately sized pieces for embedding models.
+- **Containerized:** Designed to run as a service within the main project's Docker Compose setup.
 
 ---
 
@@ -22,14 +22,15 @@ This service is configured via a `.env` file located in its directory (`embeddin
 
 Key variables:
 
--   `EMBEDDING_PROVIDER`: Set to `openai` or `gemini` to select the embedding model provider.
--   `OPENAI_API_KEY` / `GEMINI_API_KEY`: The API key for your chosen provider.
--   `OPENAI_EMBED_MODEL` / `GEMINI_EMBED_MODEL`: The specific model to use for embeddings.
--   `OPENSEARCH_HOST`: Should be set to `opensearch` to connect to the OpenSearch container within the Docker network.
--   `CHUNK_SIZE`: The size (in characters) to split large documents into.
--   `EMBED_DIM`: The vector dimension of the chosen embedding model (e.g., `1536` for OpenAI's `text-embedding-3-small`, `768` for Gemini's `text-embedding-004`).
+- `EMBEDDING_PROVIDER`: Set to `openai` or `gemini` to select the embedding model provider.
+- `OPENAI_API_KEY` / `GEMINI_API_KEY`: The API key for your chosen provider.
+- `OPENAI_EMBED_MODEL` / `GEMINI_EMBED_MODEL`: The specific model to use for embeddings.
+- `OPENSEARCH_HOST`: Should be set to `opensearch` to connect to the OpenSearch container within the Docker network.
+- `CHUNK_SIZE`: The size (in characters) to split large documents into.
+- `EMBED_DIM`: The vector dimension of the chosen embedding model (e.g., `1536` for OpenAI's `text-embedding-3-small`, `768` for Gemini's `text-embedding-004`).
 
 **Example `.env`:**
+
 ```ini
 # Provider Selection: "openai" or "gemini"
 EMBEDDING_PROVIDER=gemini
@@ -64,6 +65,8 @@ This service is not intended to be run standalone. Please refer to the **main `R
 ## 📤 API Endpoint: `POST /upload`
 
 Uploads and embeds one or more documents. The service is accessible at `http://localhost:8001` when running via Docker Compose.
+
+**Note:** This endpoint is for direct interaction with the embedding service. For most use cases, documents should be added via the `addDocumentToRASS` tool through the `mcp-server`, which acts as a gateway to this service.
 
 ### Example cURL
 

--- a/mcp-test-client/README.md
+++ b/mcp-test-client/README.md
@@ -1,0 +1,32 @@
+# MCP Test Client
+
+This directory contains a simple Node.js script to test and validate the `mcp-server` using the official `@modelcontextprotocol/sdk`.
+
+## Purpose
+
+The primary purpose of this client is to act as a "real" MCP client to ensure our `mcp-server` is fully compliant with the protocol. It verifies that the server can correctly handle connections, parse JSON-RPC messages, and execute tool calls as expected.
+
+## ⚙️ Setup
+
+From within the `mcp-test-client` directory, install the required dependencies:
+
+```bash
+npm install
+```
+
+This will install the MCP SDK and axios.
+
+## 🚀 Usage
+
+Ensure the main project's Docker environment is running (docker-compose up). Then, from within the mcp-test-client directory, run the test script:
+
+```bash
+node run-test.js
+```
+
+The script will:
+
+- Connect to the mcp-server.
+- Invoke the queryRASS tool with a sample query.
+- Print the full response received from the server to the console.
+- Close the connection.


### PR DESCRIPTION
> Creates a README for the mcp-test-client directory.
> Corrects all MCP tool examples to use 'name' instead of 'tool_name' in the root and mcp-server READMEs.
> Adds a clarification note to the embedding-service README.
> Closes #24 